### PR TITLE
Add support for command override

### DIFF
--- a/cmd/run/cmd.go
+++ b/cmd/run/cmd.go
@@ -63,11 +63,11 @@ func init() {
 	initFlags()
 }
 
-func run(cobraCommand *cobra.Command, _ []string) {
-	os.Exit(processCommand())
+func run(cobraCommand *cobra.Command, args []string) {
+	os.Exit(processCommand(args))
 }
 
-func processCommand() int {
+func processCommand(args []string) int {
 
 	if commandConfig.Hostname == "" {
 		commandConfig.Hostname = utils.RandomHostname()
@@ -113,6 +113,8 @@ func processCommand() int {
 	if commandConfig.Name != "" {
 		jailingFcConfig.WithVMMID(commandConfig.Name)
 	}
+
+	commandConfig.CaptureCmd(args)
 
 	// tracing:
 

--- a/configs/commands.go
+++ b/configs/commands.go
@@ -174,11 +174,13 @@ type RunCommandConfig struct {
 	IdentityFiles []string
 	Hostname      string
 	Name          string
+
+	cmdOverride []string
 }
 
 // NewRunCommandConfig returns new command configuration.
 func NewRunCommandConfig() *RunCommandConfig {
-	return &RunCommandConfig{}
+	return &RunCommandConfig{cmdOverride: []string{}}
 }
 
 // FlagSet returns an instance of the flag set for the configuration.
@@ -190,9 +192,20 @@ func (c *RunCommandConfig) FlagSet() *pflag.FlagSet {
 		c.flagSet.StringVar(&c.From, "from", "", "The image to launch from, for example: tests/postgres:13")
 		c.flagSet.StringArrayVar(&c.IdentityFiles, "identity-file", []string{}, "Full path to the SSH public key to deploy to the machine during bootstrap, must be regular file, multiple OK")
 		c.flagSet.StringVar(&c.Hostname, "hostname", "", "Hostname to apply to the VMM during bootstrap; if empty, a random name will be assigned")
-		c.flagSet.StringVar(&c.Name, "name", "", "Name of the VM, maximum 20 characters; allowed characters: letters, digits, . and -")
+		c.flagSet.StringVar(&c.Name, "name", "", "Name of the VM, maximum 20 characters; allowed characters: letters and digits")
 	}
 	return c.flagSet
+}
+
+// CapturedCmd retrieves the captured command override.
+func (c *RunCommandConfig) CapturedCmd() []string {
+	return c.cmdOverride
+}
+
+// CaptureCmd retrieves the command override from arguments.
+func (c *RunCommandConfig) CaptureCmd(inputargs []string) {
+	c.flagSet.Parse(inputargs)
+	c.cmdOverride = c.flagSet.Args()
 }
 
 // MergedEnvironment returns merged envirionment declared by the configuration.

--- a/configs/machine.go
+++ b/configs/machine.go
@@ -38,8 +38,8 @@ func NewMachineConfig() *MachineConfig {
 // FlagSet returns an instance of the flag set for the configuration.
 func (c *MachineConfig) FlagSet() *pflag.FlagSet {
 	if c.initFlagSet() {
-		c.flagSet.StringVar(&c.CNINetworkName, "cni-network-name", "", "CNI network within which the build should run. It's recommended to use a dedicated network for build process")
-		c.flagSet.Int64Var(&c.CPU, "cpu", 1, "Number of CPU for the build VMM")
+		c.flagSet.StringVar(&c.CNINetworkName, "cni-network-name", "", "CNI network within which the build should run; it's recommended to use a dedicated network for build process")
+		c.flagSet.Int64Var(&c.CPU, "cpu", 1, "Number of CPUs for the build VMM")
 		c.flagSet.StringVar(&c.CPUTemplate, "cpu-template", "", "CPU template (empty, C2 or T3)")
 		c.flagSet.BoolVar(&c.HTEnabled, "ht-enabled", false, "When specified, enable hyper-threading")
 		c.flagSet.StringVar(&c.KernelArgs, "kernel-args", "console=ttyS0 noapic reboot=k panic=1 pci=off nomodules rw", "Kernel arguments")
@@ -50,7 +50,7 @@ func (c *MachineConfig) FlagSet() *pflag.FlagSet {
 		c.flagSet.StringVar(&c.VMLinuxID, "vmlinux-id", "", "Kernel ID / name")
 
 		c.flagSet.BoolVar(&c.LogFcHTTPCalls, "log-firecracker-http-calls", false, "If set, logs Firecracker HTTP client calls in debug mode")
-		c.flagSet.IntVar(&c.ShutdownGracefulTimeoutSeconds, "shutdown-graceful-timeout-seconds", 30, "Grafeul shotdown timeout before vmm is stopped forcefully")
+		c.flagSet.IntVar(&c.ShutdownGracefulTimeoutSeconds, "shutdown-graceful-timeout-seconds", 30, "Graceful shutdown timeout before vmm is stopped forcefully")
 	}
 	return c.flagSet
 }

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -144,7 +144,19 @@ func (r *MDRun) AsMMDS() (interface{}, error) {
 		return nil, errors.Wrap(err, "failed fetching public keys")
 	}
 
-	entrypointJSON, err := r.Rootfs.EntrypointInfo.ToJsonString()
+	entrypoitInfo := &mmds.MMDSRootfsEntrypointInfo{
+		Cmd:        r.Rootfs.EntrypointInfo.Cmd,
+		Entrypoint: r.Rootfs.EntrypointInfo.Entrypoint,
+		Env:        r.Rootfs.EntrypointInfo.Env,
+		Shell:      r.Rootfs.EntrypointInfo.Shell,
+		User:       r.Rootfs.EntrypointInfo.User,
+		Workdir:    r.Rootfs.EntrypointInfo.Workdir,
+	}
+	if len(r.Configs.RunConfig.CapturedCmd()) > 0 {
+		entrypoitInfo.Cmd = r.Configs.RunConfig.CapturedCmd()
+	}
+
+	entrypointJSON, err := entrypoitInfo.ToJsonString()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed fetching public keys")
 	}


### PR DESCRIPTION
With this PR it is possible to override the default `cmd` loaded from the Dockerfile / Docker image. For example:

```sh
sudo $GOPATH/bin/firebuild run \
    --profile=standard \
    --from=combust-labs/consul:1.9.4 \
    --cni-network-name=machines \
    --vmlinux-id=vmlinux-v5.8 \
    -- agent -server -client 0.0.0.0 -bootstrap-expect 1 -data-dir /consul/data
```