### PR TITLE
Manual IP address assignment

### DIFF
--- a/cmd/run/cmd.go
+++ b/cmd/run/cmd.go
@@ -99,6 +99,7 @@ func processCommand(args []string) int {
 	validatingConfigs := []configs.ValidatingConfig{
 		commandConfig,
 		jailingFcConfig,
+		machineConfig,
 		runCache,
 	}
 

--- a/configs/firecracker.go
+++ b/configs/firecracker.go
@@ -73,6 +73,14 @@ func (c *defaultFcConfigProvider) ToSDKConfig() firecracker.Config {
 			CNIConfiguration: &firecracker.CNIConfiguration{
 				NetworkName: c.machineConfig.CNINetworkName,
 				IfName:      c.vethIfaceName,
+				Args: func() [][2]string {
+					if c.machineConfig.IPAddress != "" {
+						return [][2]string{
+							{"IP", c.machineConfig.IPAddress},
+						}
+					}
+					return [][2]string{}
+				}(),
 			},
 		}},
 		VsockDevices: []firecracker.VsockDevice{},


### PR DESCRIPTION
With this PR, it is possible to assign an IP address to the machine. An example of a three node Consul cluster using this functionality is now in the documentation: https://combust-labs.github.io/firebuild-docs/networking/run_network/#an-example-running-a-3-vm-hashicorp-consul-cluster.