### PR TITLE
iptables: run: publish ports on the host

### DIFF
--- a/cmd/purge/cmd.go
+++ b/cmd/purge/cmd.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/combust-labs/firebuild/configs"
+	"github.com/combust-labs/firebuild/pkg/fw"
 	"github.com/combust-labs/firebuild/pkg/profiles"
 	"github.com/combust-labs/firebuild/pkg/tracing"
 	"github.com/combust-labs/firebuild/pkg/utils"
@@ -175,7 +176,36 @@ func processCommand() int {
 
 			spanPurgeCNI.Finish()
 
-			spanPurgeCache := tracer.StartSpan("vmm-purge-cache", opentracing.ChildOf(spanPurgeCNI.Context()))
+			spanPurgeIPT := tracer.StartSpan("vmm-purge-ipt", opentracing.ChildOf(spanPurgeCNI.Context()))
+			spanPurgeIPT.SetTag("vmm-id", vmmMetadata.VMMID)
+
+			if len(vmmMetadata.Configs.RunConfig.Ports) > 0 {
+				if len(vmmMetadata.NetworkInterfaces) > 0 {
+					rootLogger.Info("cleaning up IPT")
+					mgr, err := fw.NewManager(vmmMetadata.VMMID, vmmMetadata.NetworkInterfaces[0].StaticConfiguration.IPConfiguration.IP)
+					if err != nil {
+						rootLogger.Warn("cleaning up IPT failed", "reason", err)
+					} else {
+						ports := []fw.ExposedPort{}
+						for _, port := range vmmMetadata.Configs.RunConfig.Ports {
+							parsedPort, parseErr := fw.ExposedPortFromString(port)
+							if parseErr != nil {
+								rootLogger.Warn("IP cleanup: port failed to parse", "reason", parseErr, "raw-input", port)
+							} else {
+								ports = append(ports, parsedPort)
+							}
+						}
+						if err := mgr.Unpublish(ports); err != nil {
+							rootLogger.Warn("cleaning up IPT failed", "reason", err)
+						}
+					}
+					rootLogger.Info("IPT cleaned up")
+				}
+			}
+
+			spanPurgeIPT.Finish()
+
+			spanPurgeCache := tracer.StartSpan("vmm-purge-cache", opentracing.ChildOf(spanPurgeIPT.Context()))
 			spanPurgeCache.SetTag("fs-entry", fsentry)
 
 			// have to clean up the cache

--- a/cmd/run/cmd.go
+++ b/cmd/run/cmd.go
@@ -118,6 +118,16 @@ func processCommand(args []string) int {
 
 	commandConfig.CaptureCmd(args)
 
+	exposedPorts := []fw.ExposedPort{}
+	for _, exposedPortInput := range commandConfig.Ports {
+		port, portParseErr := fw.ExposedPortFromString(exposedPortInput)
+		if portParseErr != nil {
+			rootLogger.Error("exposed port input is invalid", "reason", portParseErr)
+			return 1
+		}
+		exposedPorts = append(exposedPorts, port)
+	}
+
 	// tracing:
 
 	rootLogger.Trace("configuring tracing", "enabled", tracingConfig.Enable, "application-name", tracingConfig.ApplicationName)
@@ -330,7 +340,7 @@ func processCommand(args []string) int {
 		if publisherErr != nil {
 			rootLogger.Warn("ports not published, handling iptables failed", "reason", publisherErr)
 		} else {
-			if err := portsPublisher.Publish(commandConfig.Ports); err != nil {
+			if err := portsPublisher.Publish(exposedPorts); err != nil {
 				rootLogger.Warn("port publishing failed", "reason", err)
 			}
 		}

--- a/configs/commands.go
+++ b/configs/commands.go
@@ -174,6 +174,7 @@ type RunCommandConfig struct {
 	IdentityFiles []string
 	Hostname      string
 	Name          string
+	Ports         []string
 
 	cmdOverride []string
 }
@@ -193,6 +194,7 @@ func (c *RunCommandConfig) FlagSet() *pflag.FlagSet {
 		c.flagSet.StringArrayVar(&c.IdentityFiles, "identity-file", []string{}, "Full path to the SSH public key to deploy to the machine during bootstrap, must be regular file, multiple OK")
 		c.flagSet.StringVar(&c.Hostname, "hostname", "", "Hostname to apply to the VMM during bootstrap; if empty, a random name will be assigned")
 		c.flagSet.StringVar(&c.Name, "name", "", "Name of the VM, maximum 20 characters; allowed characters: letters and digits")
+		c.flagSet.StringArrayVar(&c.Ports, "port", []string{}, "Ports to expose on the host")
 	}
 	return c.flagSet
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/combust-labs/firebuild-mmds v0.0.12
 	github.com/combust-labs/firebuild-shared v0.0.8
 	github.com/containernetworking/cni v0.8.0
+	github.com/coreos/go-iptables v0.5.0
 	github.com/docker/docker v20.10.4+incompatible
 	github.com/firecracker-microvm/firecracker-go-sdk v0.22.0
 	github.com/go-git/go-git/v5 v5.2.0

--- a/go.sum
+++ b/go.sum
@@ -244,6 +244,8 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-iptables v0.4.5/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
+github.com/coreos/go-iptables v0.5.0 h1:mw6SAibtHKZcNzAsOxjoHIG0gy5YFHhypWSSNc6EjbQ=
+github.com/coreos/go-iptables v0.5.0/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/pkg/flock/flock.go
+++ b/pkg/flock/flock.go
@@ -1,0 +1,104 @@
+package flock
+
+import (
+	"syscall"
+	"time"
+)
+
+type acquireTimeoutError string
+type acquireFailedError string
+
+// ErrTimeout indicates that the lock attempt timed out.
+var ErrTimeout error = acquireTimeoutError("acquire timeout exceeded")
+
+func (t acquireTimeoutError) Error() string {
+	return string(t)
+}
+
+// ErrLocked indicates TryLock failed because the lock was already locked.
+var ErrLocked error = acquireFailedError("already locked")
+
+func (t acquireFailedError) Error() string {
+	return string(t)
+}
+
+// Lock implements flock syscall based cross-process locking.
+type Lock interface {
+	Acquire() error
+	AcquireWithTimeout(time.Duration) error
+	TryAcquire() error
+	Release() error
+}
+
+type defaultLock struct {
+	filename string
+	fd       int
+}
+
+// New returns a new lock around the given file.
+func New(filename string) Lock {
+	return &defaultLock{filename: filename}
+}
+
+// Acquire attempts acquiring the lock. Will block until the lock becomes available.
+func (l *defaultLock) Acquire() error {
+	if err := l.open(); err != nil {
+		return err
+	}
+	return syscall.Flock(l.fd, syscall.LOCK_EX)
+}
+
+// AcquireWithTimeout attempts to acquire the lock until the timeout expires. Blocking.
+func (l *defaultLock) AcquireWithTimeout(timeout time.Duration) error {
+	if err := l.open(); err != nil {
+		return err
+	}
+	result := make(chan error)
+	cancel := make(chan struct{})
+	go func() {
+		err := syscall.Flock(l.fd, syscall.LOCK_EX)
+		select {
+		case <-cancel: // Timed out, maybe cleanup.
+			syscall.Flock(l.fd, syscall.LOCK_UN)
+			syscall.Close(l.fd)
+		case result <- err:
+		}
+	}()
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(timeout):
+		close(cancel)
+		return ErrTimeout
+	}
+}
+
+// Release releases the flock.
+func (l *defaultLock) Release() error {
+	return syscall.Close(l.fd)
+}
+
+// TryLock attempts to lock the lock.  This method will return ErrLocked
+// immediately if the lock cannot be acquired.
+func (l *defaultLock) TryAcquire() error {
+	if err := l.open(); err != nil {
+		return err
+	}
+	err := syscall.Flock(l.fd, syscall.LOCK_EX|syscall.LOCK_NB)
+	if err != nil {
+		syscall.Close(l.fd)
+	}
+	if err == syscall.EWOULDBLOCK {
+		return ErrLocked
+	}
+	return err
+}
+
+func (l *defaultLock) open() error {
+	fd, err := syscall.Open(l.filename, syscall.O_CREAT|syscall.O_RDONLY, 0600)
+	if err != nil {
+		return err
+	}
+	l.fd = fd
+	return nil
+}

--- a/pkg/fw/exposed_port.go
+++ b/pkg/fw/exposed_port.go
@@ -1,0 +1,203 @@
+package fw
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+const defaultProtocol = "tcp"
+
+// ExposedPort represents exposed port data used for iptables port publishing.
+type ExposedPort interface {
+	Interface() *string
+	HostPort() int
+	DestinationPort() int
+	Protocol() string
+
+	ToForwardRulespec(targetAddress string) []string
+	ToNATRulespec(targetAddress string) []string
+}
+
+type defaultExposedPort struct {
+	iface           *string
+	hostPort        int
+	destinationPort int
+	protocol        string
+}
+
+// Interface returns the exposed interface or nil, if port should be exposed on all interfaces.
+func (p *defaultExposedPort) Interface() *string {
+	return p.iface
+}
+
+// HostPort returns the host port value.
+func (p *defaultExposedPort) HostPort() int {
+	return p.hostPort
+}
+
+// DestinationPort returns the guest destination port value.
+func (p *defaultExposedPort) DestinationPort() int {
+	return p.destinationPort
+}
+
+// Protocol returns the protocol value: tcp or udp.
+func (p *defaultExposedPort) Protocol() string {
+	return p.protocol
+}
+
+func (p *defaultExposedPort) toCommentValue() string {
+	return fmt.Sprintf("firebuild:%s:%d:%d:/%s", func() string {
+		if p.Interface() == nil {
+			return "*"
+		}
+		return *p.Interface()
+	}(), p.HostPort(), p.DestinationPort(), p.Protocol())
+}
+
+// ToForwardRulespec returns the forward chain rulespec for this port.
+func (p *defaultExposedPort) ToForwardRulespec(targetAddress string) []string {
+	rulespec := []string{"-m", "comment", "--comment", p.toCommentValue(), "-p", p.Protocol()}
+	if p.Interface() != nil {
+		rulespec = append(rulespec, "-i", *p.Interface())
+	}
+	return append(rulespec, "-d", targetAddress, "--dport", fmt.Sprintf("%d", p.HostPort()), "-m", "state", "--state", "NEW,ESTABLISHED,RELATED", "-j", "ACCEPT")
+}
+
+// ToNATRulespec returns the forward chain rulespec for this port.
+func (p *defaultExposedPort) ToNATRulespec(targetAddress string) []string {
+	rulespec := []string{"-m", "comment", "--comment", p.toCommentValue(), "-p", p.Protocol()}
+	if p.Interface() != nil {
+		rulespec = append(rulespec, "-i", *p.Interface())
+	}
+	return append(rulespec, "--dport", fmt.Sprintf("%d", p.HostPort()), "-j", "DNAT", "--to-destination", fmt.Sprintf("%s:%d", targetAddress, p.DestinationPort()))
+}
+
+var (
+	extractionRegex = regexp.MustCompile("^((.[^:]*):)?((\\d{2,5}):)?(\\d{2,5})(\\/[a-z]{3})?$")
+)
+
+// ExposedPortFromString attempts to parse the input as an exposed port.
+func ExposedPortFromString(input string) (ExposedPort, error) {
+	matches := extractionRegex.FindAllStringSubmatch(input, -1)
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("string is not a valid exposed port")
+	}
+	if len(matches[0]) == 0 {
+		return nil, fmt.Errorf("string is not a valid exposed port")
+	}
+
+	values := matches[0]
+	// skip first item because it's the full match:
+	values = values[1:]
+	// remove values ending with : and empty
+	newValues := []string{}
+	for _, v := range values {
+		if v == "" || v[len(v)-1] == ':' {
+			continue
+		}
+		newValues = append(newValues, v)
+	}
+
+	if len(newValues) == 4 {
+		// interface:host-port:dest-port:protocol format
+		intVal1, parseErr1 := parsedPortOrError(newValues[1])
+		intVal2, parseErr2 := parsedPortOrError(newValues[2])
+		if parseErr1 != nil || parseErr2 != nil { // both middle values must be valid port numbers
+			return nil, fmt.Errorf("input %q cannot be parsed as exposed value", input)
+		}
+		if !validProtocol(newValues[3]) {
+			return nil, fmt.Errorf("value %q is not a valid protocol", newValues[3])
+		}
+		return &defaultExposedPort{iface: pstring(newValues[0]), hostPort: intVal1, destinationPort: intVal2, protocol: newValues[3][1:]}, nil
+	}
+
+	if len(newValues) == 3 {
+		// interface:host-port:dest-port format
+		// or
+		// host-port:dest-port:protocol format
+		intVal1, parseErr1 := parsedPortOrError(newValues[0])
+		intVal2, parseErr2 := parsedPortOrError(newValues[1])
+		intVal3, parseErr3 := parsedPortOrError(newValues[2])
+
+		if parseErr1 != nil { // expected interface:host-port:dest-port format
+			if parseErr2 != nil || parseErr3 != nil { // but 1 and 2 failed as port values, no match
+				return nil, fmt.Errorf("input %q cannot be parsed as exposed value", input)
+			}
+			return &defaultExposedPort{iface: pstring(newValues[0]), hostPort: intVal2, destinationPort: intVal3, protocol: defaultProtocol}, nil
+		}
+
+		if parseErr3 != nil { // expected host-port:dest-port:protocol format
+			if parseErr1 != nil || parseErr2 != nil { // but 0 and 1 failed as port values, no match
+				return nil, fmt.Errorf("input %q cannot be parsed as exposed value", input)
+			}
+			return &defaultExposedPort{iface: nil, hostPort: intVal1, destinationPort: intVal2, protocol: newValues[2][1:]}, nil
+		}
+
+		return nil, fmt.Errorf("input %q cannot be parsed as exposed value", input)
+
+	}
+
+	if len(newValues) == 2 {
+		// interface:dest-port format
+		// or
+		// host-port:dest-port format
+		// or
+		// dest-port:protocol format
+
+		intVal1, parseErr1 := parsedPortOrError(newValues[0])
+		intVal2, parseErr2 := parsedPortOrError(newValues[1])
+
+		if parseErr1 == nil && parseErr2 == nil { // host-port:dest-port format
+			return &defaultExposedPort{iface: nil, hostPort: intVal1, destinationPort: intVal2, protocol: defaultProtocol}, nil
+		}
+
+		if parseErr1 != nil && parseErr2 == nil { // interface:dest-port format
+			return &defaultExposedPort{iface: pstring(newValues[0]), hostPort: intVal2, destinationPort: intVal2, protocol: defaultProtocol}, nil
+		}
+
+		if parseErr1 == nil && parseErr2 != nil { // dest-port:protocol format
+			if !validProtocol(newValues[1]) {
+				return nil, fmt.Errorf("value %q is not a valid protocol", newValues[1])
+			}
+			return &defaultExposedPort{iface: nil, hostPort: intVal1, destinationPort: intVal1, protocol: newValues[1][1:]}, nil
+		}
+
+		// both errors are not nil, invalid state:
+		return nil, fmt.Errorf("input %q cannot be parsed as exposed value", input)
+	}
+
+	if len(newValues) == 1 {
+		// dest-port only:
+		intVal, parseErr := parsedPortOrError(newValues[0])
+		if parseErr != nil {
+			return nil, parseErr
+		}
+		return &defaultExposedPort{iface: nil, hostPort: intVal, destinationPort: intVal, protocol: defaultProtocol}, nil
+	}
+
+	return nil, fmt.Errorf("input not valid")
+}
+
+func pstring(input string) *string {
+	return &input
+}
+
+func parsedPortOrError(input string) (int, error) {
+	intVal, parseErr := strconv.Atoi(input)
+	if parseErr != nil {
+		return 0, errors.Wrap(parseErr, "string is not a valid exposed port")
+	}
+	if !validPort(intVal) {
+		return 0, fmt.Errorf("value %d is not a valid port", intVal)
+	}
+	return intVal, nil
+}
+func validPort(v int) bool {
+	return v > 0 && v < 65535
+}
+func validProtocol(v string) bool {
+	return v == "/tcp" || v == "/udp"
+}

--- a/pkg/fw/exposed_port_test.go
+++ b/pkg/fw/exposed_port_test.go
@@ -1,0 +1,106 @@
+package fw
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExposedPortExtractFail(t *testing.T) {
+
+	_, err1 := ExposedPortFromString("aaa:aaa:aaa:aaa:aaa:aaaa:16686a:16686/tcp")
+	assert.NotNil(t, err1)
+
+	_, err2 := ExposedPortFromString("eno1:16686:166867/tcp")
+	assert.NotNil(t, err2)
+
+	_, err3 := ExposedPortFromString("eno1:16686a:16686/tcp")
+	assert.NotNil(t, err3)
+
+	_, err4 := ExposedPortFromString("eno1:166867:16686/tcp")
+	assert.NotNil(t, err4)
+
+	_, err5 := ExposedPortFromString("eno1:16686:16686/definitelynot")
+	assert.NotNil(t, err5)
+}
+
+func TestExposedPortExtractSuccess(t *testing.T) {
+
+	ep, err1 := ExposedPortFromString("eno1:16686:16686/tcp")
+	assert.Nil(t, err1)
+	assert.NotNil(t, ep.Interface())
+	assert.Equal(t, ep.HostPort(), 16686)
+	assert.Equal(t, ep.DestinationPort(), 16686)
+	assert.Equal(t, ep.Protocol(), defaultProtocol)
+
+	assert.Equal(t, []string{"-m", "comment", "--comment", "firebuild:eno1:16686:16686:/tcp",
+		"-p", "tcp", "-i", "eno1", "-d", "127.0.0.1", "--dport", "16686",
+		"-m", "state", "--state", "NEW,ESTABLISHED,RELATED", "-j", "ACCEPT"}, ep.ToForwardRulespec("127.0.0.1"))
+	assert.Equal(t, []string{"-m", "comment", "--comment", "firebuild:eno1:16686:16686:/tcp",
+		"-p", "tcp", "-i", "eno1", "--dport", "16686",
+		"-j", "DNAT", "--to-destination", "127.0.0.1:16686"}, ep.ToNATRulespec("127.0.0.1"))
+
+	ep, err2 := ExposedPortFromString("eno1:16687:16686/tcp")
+	assert.Nil(t, err2)
+	assert.NotNil(t, ep.Interface())
+	assert.Equal(t, ep.HostPort(), 16687)
+	assert.Equal(t, ep.DestinationPort(), 16686)
+	assert.Equal(t, ep.Protocol(), defaultProtocol)
+
+	ep, err3 := ExposedPortFromString("eno1:16686:16687/udp")
+	assert.Nil(t, err3)
+	assert.NotNil(t, ep.Interface())
+	assert.Equal(t, ep.HostPort(), 16686)
+	assert.Equal(t, ep.DestinationPort(), 16687)
+	assert.Equal(t, ep.Protocol(), "udp")
+
+	ep, err4 := ExposedPortFromString("eno1:16686:16686")
+	assert.Nil(t, err4)
+	assert.NotNil(t, ep.Interface())
+	assert.Equal(t, ep.HostPort(), 16686)
+	assert.Equal(t, ep.DestinationPort(), 16686)
+	assert.Equal(t, ep.Protocol(), "tcp")
+
+	ep, err5 := ExposedPortFromString("16687:16686/udp")
+	assert.Nil(t, err5)
+	assert.Nil(t, ep.Interface())
+	assert.Equal(t, ep.HostPort(), 16687)
+	assert.Equal(t, ep.DestinationPort(), 16686)
+	assert.Equal(t, ep.Protocol(), "udp")
+
+	assert.Equal(t, []string{"-m", "comment", "--comment", "firebuild:*:16687:16686:/udp",
+		"-p", "udp", "-d", "127.0.0.1", "--dport", "16687",
+		"-m", "state", "--state", "NEW,ESTABLISHED,RELATED", "-j", "ACCEPT"}, ep.ToForwardRulespec("127.0.0.1"))
+	assert.Equal(t, []string{"-m", "comment", "--comment", "firebuild:*:16687:16686:/udp",
+		"-p", "udp", "--dport", "16687",
+		"-j", "DNAT", "--to-destination", "127.0.0.1:16686"}, ep.ToNATRulespec("127.0.0.1"))
+
+	ep, err6 := ExposedPortFromString("eno1:16686")
+	assert.Nil(t, err6)
+	assert.NotNil(t, ep.Interface())
+	assert.Equal(t, ep.HostPort(), 16686)
+	assert.Equal(t, ep.DestinationPort(), 16686)
+	assert.Equal(t, ep.Protocol(), defaultProtocol)
+
+	ep, err7 := ExposedPortFromString("16687:16686")
+	assert.Nil(t, err7)
+	assert.Nil(t, ep.Interface())
+	assert.Equal(t, ep.HostPort(), 16687)
+	assert.Equal(t, ep.DestinationPort(), 16686)
+	assert.Equal(t, ep.Protocol(), defaultProtocol)
+
+	ep, err8 := ExposedPortFromString("16686/udp")
+	assert.Nil(t, err8)
+	assert.Nil(t, ep.Interface())
+	assert.Equal(t, ep.HostPort(), 16686)
+	assert.Equal(t, ep.DestinationPort(), 16686)
+	assert.Equal(t, ep.Protocol(), "udp")
+
+	ep, err9 := ExposedPortFromString("16686")
+	assert.Nil(t, err9)
+	assert.Nil(t, ep.Interface())
+	assert.Equal(t, ep.HostPort(), 16686)
+	assert.Equal(t, ep.DestinationPort(), 16686)
+	assert.Equal(t, ep.Protocol(), defaultProtocol)
+
+}

--- a/pkg/fw/fw.go
+++ b/pkg/fw/fw.go
@@ -3,6 +3,7 @@ package fw
 import (
 	"fmt"
 
+	"github.com/combust-labs/firebuild/pkg/utils"
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/pkg/errors"
 )
@@ -10,94 +11,133 @@ import (
 // Maximum chain name length is 29 characters
 // VM ID is maximum 20 characters + '-' leaves us with 8 characters free.
 
-// this cannot handle concurrent requests
-// this needs to run as a daemon on the host
-
 const (
-	firebuildFilterChainName    = "FIREBUILD-FILTER"
-	firebuildFilterChainComment = "firebuild:forward"
+	// FirebuildIptFilterChainNameEnvVarName is the name of the environment variable which can be used
+	// to override the default firebuild filter chain name.
+	FirebuildIptFilterChainNameEnvVarName = "FIREBUILD_IPT_FILTER_CHAIN_NAME"
+	// FirebuildIptDefaultFilterChainName is the default firebuild filer chain name.
+	FirebuildIptDefaultFilterChainName = "FIREBUILD-FILTER"
 )
 
-type IPTPublisher interface {
-	Publish([]string) error
+// IPTManager manages filter and nat rules for VM exposed ports.
+type IPTManager interface {
+	// Publish publishes exposed ports. Creates a nat table chain if necessary.
+	Publish([]ExposedPort) error
+	// Unpublish removes exposed ports. Removes the nat table chain if necessary.
+	Unpublish([]ExposedPort) error
 }
 
-type defaultPublisher struct {
+type defaultManager struct {
 	ipt       *iptables.IPTables
 	vmID      string
 	ipAddress string
 
-	natChainName string
+	filterChainName string
+	natChainName    string
 }
 
-func NewPublisher(vmID, ipAddress string) (IPTPublisher, error) {
+// NewPublisher returns a publisher with configured firebuild filter chain in the filter table.
+// If chain fails to initialize, returns an error.
+// Locking happens in:
+// - this initializer because the top level filter chain is created here
+// - in Publish
+// - in Unpublish
+func NewPublisher(vmID, ipAddress string) (IPTManager, error) {
 	ipt, err := iptables.New()
 	if err != nil {
 		return nil, err
 	}
-	publisher := &defaultPublisher{ipt: ipt,
-		vmID:         vmID,
-		ipAddress:    ipAddress,
-		natChainName: fmt.Sprintf("FBD-%s", vmID)}
+	publisher := &defaultManager{ipt: ipt,
+		vmID:            vmID,
+		ipAddress:       ipAddress,
+		filterChainName: utils.GetenvOrDefault(FirebuildIptFilterChainNameEnvVarName, FirebuildIptDefaultFilterChainName),
+		natChainName:    fmt.Sprintf("FBD-%s", vmID)}
+	// TODO: file system based lock
 	if err := publisher.ensureFilterChain(); err != nil {
-		return nil, err
-	}
-	if err := publisher.ensureNATChain(); err != nil {
 		return nil, err
 	}
 	return publisher, nil
 }
 
-func (p *defaultPublisher) Publish(ports []string) error {
+// Publish publishes exposed ports. Creates a nat table chain if necessary.
+func (p *defaultManager) Publish(ports []ExposedPort) error {
+	// TODO: file system based lock
+	if err := p.ensureNATChain(); err != nil {
+		return err
+	}
 	for _, port := range ports {
-		if err := p.ipt.AppendUnique("filter", firebuildFilterChainName,
-			"-m", "comment", "--comment", fmt.Sprintf("firebuild:%s:%s", p.vmID, port),
-			"-p", "tcp", "-d", p.ipAddress, "--dport", port,
-			"-m", "state", "--state", "NEW,ESTABLISHED,RELATED", "-j", "ACCEPT"); err != nil {
+		if err := p.ipt.AppendUnique("filter", p.filterChainName, port.ToForwardRulespec(p.ipAddress)...); err != nil {
 			return errors.Wrapf(err, "failed exposing filter table port: %s", port)
 		}
-		if err := p.ipt.AppendUnique("nat", p.natChainName,
-			"-m", "comment", "--comment", fmt.Sprintf("firebuild:%s:%s", p.vmID, port),
-			"-p", "tcp", "--dport", port,
-			"-j", "DNAT",
-			"--to-destination", fmt.Sprintf("%s:%s", p.ipAddress, port)); err != nil {
+		if err := p.ipt.AppendUnique("nat", p.natChainName, port.ToNATRulespec(p.ipAddress)...); err != nil {
 			return errors.Wrapf(err, "failed exposing nat table port: %s", port)
 		}
 	}
 	return nil
 }
 
-func (p *defaultPublisher) ensureFilterChain() error {
-	if err := p.ensureChain("filter", firebuildFilterChainName); err != nil {
+// Unpublish removes exposed ports. Removes the nat table chain if necessary.
+func (p *defaultManager) Unpublish(ports []ExposedPort) error {
+	// TODO: file system based lock
+	for _, port := range ports {
+		if err := p.ipt.DeleteIfExists("filter", p.filterChainName, port.ToForwardRulespec(p.ipAddress)...); err != nil {
+			return errors.Wrapf(err, "failed removing filter table port: %s", port)
+		}
+		if err := p.ipt.DeleteIfExists("nat", p.natChainName, port.ToNATRulespec(p.ipAddress)...); err != nil {
+			return errors.Wrapf(err, "failed removing nat table port: %s", port)
+		}
+	}
+	return p.removeNATChain()
+}
+
+func (p *defaultManager) ensureFilterChain() error {
+	if err := ensureChain(p.ipt, "filter", p.filterChainName); err != nil {
 		return err
 	}
-	if err := p.ipt.AppendUnique("filter", "FORWARD",
-		"-m", "comment", "--comment", firebuildFilterChainComment,
-		"-j", firebuildFilterChainName); err != nil {
+	if err := p.ipt.AppendUnique("filter", "FORWARD", "-j", p.filterChainName); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (p *defaultPublisher) ensureNATChain() error {
-	if err := p.ensureChain("nat", p.natChainName); err != nil {
+func (p *defaultManager) ensureNATChain() error {
+	if err := ensureChain(p.ipt, "nat", p.natChainName); err != nil {
 		return err
 	}
-	if err := p.ipt.AppendUnique("nat", "PREROUTING",
-		"-m", "comment", "--comment", fmt.Sprintf("firebuild:managed:%s", p.vmID),
-		"-j", p.natChainName); err != nil {
+	if err := p.ipt.AppendUnique("nat", "PREROUTING", "-j", p.natChainName); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (p *defaultPublisher) ensureChain(table, name string) error {
-	exists, err := p.ipt.ChainExists(table, name)
+func (p *defaultManager) removeNATChain() error {
+	if err := p.ipt.DeleteIfExists("nat", "PREROUTING", "-j", p.natChainName); err != nil {
+		return err
+	}
+	if err := removeChain(p.ipt, "nat", p.natChainName); err != nil {
+		return err
+	}
+	return nil
+}
+
+func ensureChain(ipt *iptables.IPTables, table, name string) error {
+	exists, err := ipt.ChainExists(table, name)
 	if err != nil {
 		return err
 	}
 	if !exists {
-		return p.ipt.NewChain(table, name)
+		return ipt.NewChain(table, name)
+	}
+	return nil
+}
+
+func removeChain(ipt *iptables.IPTables, table, name string) error {
+	exists, err := ipt.ChainExists(table, name)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return ipt.DeleteChain(table, name)
 	}
 	return nil
 }

--- a/pkg/fw/fw.go
+++ b/pkg/fw/fw.go
@@ -2,7 +2,9 @@ package fw
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/combust-labs/firebuild/pkg/flock"
 	"github.com/combust-labs/firebuild/pkg/utils"
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/pkg/errors"
@@ -17,6 +19,18 @@ const (
 	FirebuildIptFilterChainNameEnvVarName = "FIREBUILD_IPT_FILTER_CHAIN_NAME"
 	// FirebuildIptDefaultFilterChainName is the default firebuild filer chain name.
 	FirebuildIptDefaultFilterChainName = "FIREBUILD-FILTER"
+
+	// FirebuildFlockDefaultFile is the default IPT flock path.
+	FirebuildFlockDefaultFile = "/tmp/iptables.lock"
+	// FirebuildFlockFileEnvVarName is the name of the environment variable which can be used to
+	// override the default flock file path.
+	FirebuildFlockFileEnvVarName = "FIREBUILD_IPT_FLOCK_FILE"
+
+	// FirebuildFlockDefaultAcquireTimeout is the default timeout value.
+	FirebuildFlockDefaultAcquireTimeout = "10s"
+	// FirebuildFlockFileEnvVarName is the name of the environment variable which can be used to
+	// override the default flock file path.
+	FirebuildFlockAcquireTimeoutEnvVarName = "FIREBUILD_IPT_FLOCK_ACQUIRE_TIMEOUT"
 )
 
 // IPTManager manages filter and nat rules for VM exposed ports.
@@ -32,27 +46,37 @@ type defaultManager struct {
 	vmID      string
 	ipAddress string
 
-	filterChainName string
-	natChainName    string
+	lock               flock.Lock
+	lockAcquireTimeout time.Duration
+	filterChainName    string
+	natChainName       string
 }
 
-// NewPublisher returns a publisher with configured firebuild filter chain in the filter table.
+// NewManager returns a publisher with configured firebuild filter chain in the filter table.
 // If chain fails to initialize, returns an error.
 // Locking happens in:
-// - this initializer because the top level filter chain is created here
+// - ensureFilterChain, called only when creating new manager
 // - in Publish
 // - in Unpublish
-func NewPublisher(vmID, ipAddress string) (IPTManager, error) {
+func NewManager(vmID, ipAddress string) (IPTManager, error) {
+
+	acquiteTimeout, err := time.ParseDuration(utils.GetenvOrDefault(FirebuildFlockAcquireTimeoutEnvVarName, FirebuildFlockDefaultAcquireTimeout))
+	if err != nil {
+		return nil, err
+	}
+
 	ipt, err := iptables.New()
 	if err != nil {
 		return nil, err
 	}
+
 	publisher := &defaultManager{ipt: ipt,
-		vmID:            vmID,
-		ipAddress:       ipAddress,
-		filterChainName: utils.GetenvOrDefault(FirebuildIptFilterChainNameEnvVarName, FirebuildIptDefaultFilterChainName),
-		natChainName:    fmt.Sprintf("FBD-%s", vmID)}
-	// TODO: file system based lock
+		vmID:               vmID,
+		ipAddress:          ipAddress,
+		lock:               flock.New(utils.GetenvOrDefault(FirebuildFlockFileEnvVarName, FirebuildFlockDefaultFile)),
+		lockAcquireTimeout: acquiteTimeout,
+		filterChainName:    utils.GetenvOrDefault(FirebuildIptFilterChainNameEnvVarName, FirebuildIptDefaultFilterChainName),
+		natChainName:       fmt.Sprintf("FBD-%s", vmID)}
 	if err := publisher.ensureFilterChain(); err != nil {
 		return nil, err
 	}
@@ -61,7 +85,12 @@ func NewPublisher(vmID, ipAddress string) (IPTManager, error) {
 
 // Publish publishes exposed ports. Creates a nat table chain if necessary.
 func (p *defaultManager) Publish(ports []ExposedPort) error {
-	// TODO: file system based lock
+
+	if err := p.lock.AcquireWithTimeout(p.lockAcquireTimeout); err != nil {
+		return err
+	}
+	defer p.lock.Release()
+
 	if err := p.ensureNATChain(); err != nil {
 		return err
 	}
@@ -78,7 +107,12 @@ func (p *defaultManager) Publish(ports []ExposedPort) error {
 
 // Unpublish removes exposed ports. Removes the nat table chain if necessary.
 func (p *defaultManager) Unpublish(ports []ExposedPort) error {
-	// TODO: file system based lock
+
+	if err := p.lock.AcquireWithTimeout(p.lockAcquireTimeout); err != nil {
+		return err
+	}
+	defer p.lock.Release()
+
 	for _, port := range ports {
 		if err := p.ipt.DeleteIfExists("filter", p.filterChainName, port.ToForwardRulespec(p.ipAddress)...); err != nil {
 			return errors.Wrapf(err, "failed removing filter table port: %s", port)
@@ -91,6 +125,12 @@ func (p *defaultManager) Unpublish(ports []ExposedPort) error {
 }
 
 func (p *defaultManager) ensureFilterChain() error {
+
+	if err := p.lock.AcquireWithTimeout(p.lockAcquireTimeout); err != nil {
+		return err
+	}
+	defer p.lock.Release()
+
 	if err := ensureChain(p.ipt, "filter", p.filterChainName); err != nil {
 		return err
 	}

--- a/pkg/fw/fw.go
+++ b/pkg/fw/fw.go
@@ -28,8 +28,8 @@ const (
 
 	// FirebuildFlockDefaultAcquireTimeout is the default timeout value.
 	FirebuildFlockDefaultAcquireTimeout = "10s"
-	// FirebuildFlockFileEnvVarName is the name of the environment variable which can be used to
-	// override the default flock file path.
+	// FirebuildFlockAcquireTimeoutEnvVarName is the name of the environment variable which can be used to
+	// override the default flock acquire timeout.
 	FirebuildFlockAcquireTimeoutEnvVarName = "FIREBUILD_IPT_FLOCK_ACQUIRE_TIMEOUT"
 )
 

--- a/pkg/fw/fw.go
+++ b/pkg/fw/fw.go
@@ -1,0 +1,103 @@
+package fw
+
+import (
+	"fmt"
+
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/pkg/errors"
+)
+
+// Maximum chain name length is 29 characters
+// VM ID is maximum 20 characters + '-' leaves us with 8 characters free.
+
+// this cannot handle concurrent requests
+// this needs to run as a daemon on the host
+
+const (
+	firebuildFilterChainName    = "FIREBUILD-FILTER"
+	firebuildFilterChainComment = "firebuild:forward"
+)
+
+type IPTPublisher interface {
+	Publish([]string) error
+}
+
+type defaultPublisher struct {
+	ipt       *iptables.IPTables
+	vmID      string
+	ipAddress string
+
+	natChainName string
+}
+
+func NewPublisher(vmID, ipAddress string) (IPTPublisher, error) {
+	ipt, err := iptables.New()
+	if err != nil {
+		return nil, err
+	}
+	publisher := &defaultPublisher{ipt: ipt,
+		vmID:         vmID,
+		ipAddress:    ipAddress,
+		natChainName: fmt.Sprintf("FBD-%s", vmID)}
+	if err := publisher.ensureFilterChain(); err != nil {
+		return nil, err
+	}
+	if err := publisher.ensureNATChain(); err != nil {
+		return nil, err
+	}
+	return publisher, nil
+}
+
+func (p *defaultPublisher) Publish(ports []string) error {
+	for _, port := range ports {
+		if err := p.ipt.AppendUnique("filter", firebuildFilterChainName,
+			"-m", "comment", "--comment", fmt.Sprintf("firebuild:%s:%s", p.vmID, port),
+			"-p", "tcp", "-d", p.ipAddress, "--dport", port,
+			"-m", "state", "--state", "NEW,ESTABLISHED,RELATED", "-j", "ACCEPT"); err != nil {
+			return errors.Wrapf(err, "failed exposing filter table port: %s", port)
+		}
+		if err := p.ipt.AppendUnique("nat", p.natChainName,
+			"-m", "comment", "--comment", fmt.Sprintf("firebuild:%s:%s", p.vmID, port),
+			"-p", "tcp", "--dport", port,
+			"-j", "DNAT",
+			"--to-destination", fmt.Sprintf("%s:%s", p.ipAddress, port)); err != nil {
+			return errors.Wrapf(err, "failed exposing nat table port: %s", port)
+		}
+	}
+	return nil
+}
+
+func (p *defaultPublisher) ensureFilterChain() error {
+	if err := p.ensureChain("filter", firebuildFilterChainName); err != nil {
+		return err
+	}
+	if err := p.ipt.AppendUnique("filter", "FORWARD",
+		"-m", "comment", "--comment", firebuildFilterChainComment,
+		"-j", firebuildFilterChainName); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *defaultPublisher) ensureNATChain() error {
+	if err := p.ensureChain("nat", p.natChainName); err != nil {
+		return err
+	}
+	if err := p.ipt.AppendUnique("nat", "PREROUTING",
+		"-m", "comment", "--comment", fmt.Sprintf("firebuild:managed:%s", p.vmID),
+		"-j", p.natChainName); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *defaultPublisher) ensureChain(table, name string) error {
+	exists, err := p.ipt.ChainExists(table, name)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return p.ipt.NewChain(table, name)
+	}
+	return nil
+}

--- a/pkg/fw/fw_test.go
+++ b/pkg/fw/fw_test.go
@@ -40,7 +40,7 @@ func TestIPTPublishAndCleanup(t *testing.T) {
 
 	os.Setenv(FirebuildIptFilterChainNameEnvVarName, testFilterChainName)
 
-	mgr, err := NewPublisher(vmID, targetAddress)
+	mgr, err := NewManager(vmID, targetAddress)
 	assert.Nil(t, err)
 
 	publishErr := mgr.Publish(ports)

--- a/pkg/fw/fw_test.go
+++ b/pkg/fw/fw_test.go
@@ -1,0 +1,111 @@
+package fw
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"testing"
+
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIPTPublishAndCleanup(t *testing.T) {
+
+	user, err := user.Current()
+
+	if user.Uid != "0" {
+		t.Skip("Skipping tests depending on sudo: run tests with sudo to have this test executed")
+	}
+
+	vmID := "testvm"
+	targetAddress := "127.0.0.1"
+	testFilterChainName := "TEST-CHAIN"
+	natChainName := fmt.Sprintf("FBD-%s", vmID)
+
+	ports := []ExposedPort{
+		&defaultExposedPort{
+			iface:           nil,
+			hostPort:        1234,
+			destinationPort: 12345,
+			protocol:        "tcp",
+		},
+		&defaultExposedPort{
+			iface:           pstring("eno1"),
+			hostPort:        2345,
+			destinationPort: 23456,
+			protocol:        "udp",
+		},
+	}
+
+	os.Setenv(FirebuildIptFilterChainNameEnvVarName, testFilterChainName)
+
+	mgr, err := NewPublisher(vmID, targetAddress)
+	assert.Nil(t, err)
+
+	publishErr := mgr.Publish(ports)
+	assert.Nil(t, publishErr)
+
+	ipt, err := iptables.New()
+	assert.Nil(t, err)
+
+	fcexists, err := ipt.ChainExists("filter", testFilterChainName)
+	assert.Nil(t, err)
+	assert.True(t, fcexists)
+
+	ncexists, err := ipt.ChainExists("nat", natChainName)
+	assert.Nil(t, err)
+	assert.True(t, ncexists)
+
+	ruleexists, err := ipt.Exists("filter", "FORWARD", "-j", testFilterChainName)
+	assert.Nil(t, err)
+	assert.True(t, ruleexists)
+
+	ruleexists, err = ipt.Exists("nat", "PREROUTING", "-j", natChainName)
+	assert.Nil(t, err)
+	assert.True(t, ruleexists)
+
+	for _, port := range ports {
+		ruleexists, err = ipt.Exists("filter", testFilterChainName, port.ToForwardRulespec(targetAddress)...)
+		assert.Nil(t, err)
+		assert.True(t, ruleexists)
+
+		ruleexists, err = ipt.Exists("nat", natChainName, port.ToNATRulespec(targetAddress)...)
+		assert.Nil(t, err)
+		assert.True(t, ruleexists)
+	}
+
+	// cleanup:
+	unpublishErr := mgr.Unpublish(ports)
+	assert.Nil(t, unpublishErr)
+
+	// forward chain should remain:
+	fcexists, err = ipt.ChainExists("filter", testFilterChainName)
+	assert.Nil(t, err)
+	assert.True(t, fcexists)
+
+	// VM chain should be removed from nat table:
+	ncexists, err = ipt.ChainExists("nat", fmt.Sprintf("FBD-%s", vmID))
+	assert.Nil(t, err)
+	assert.False(t, ncexists)
+
+	// the forward rule to the firebuild chain should remain:
+	ruleexists, err = ipt.Exists("filter", "FORWARD", "-j", testFilterChainName)
+	assert.Nil(t, err)
+	assert.True(t, ruleexists)
+
+	// nat prerouting rule must be gone:
+	ruleexists, err = ipt.Exists("nat", "PREROUTING", "-j", natChainName)
+	assert.NotNil(t, err)
+
+	for _, port := range ports {
+		ruleexists, err = ipt.Exists("filter", testFilterChainName, port.ToForwardRulespec(targetAddress)...)
+		assert.Nil(t, err)
+		assert.False(t, ruleexists)
+
+		ruleexists, err = ipt.Exists("nat", natChainName, port.ToNATRulespec(targetAddress)...)
+		assert.Nil(t, err)
+		assert.False(t, ruleexists)
+	}
+
+}

--- a/pkg/utils/os.go
+++ b/pkg/utils/os.go
@@ -74,6 +74,14 @@ func CreateRootFSFile(path string, size int) error {
 	return nil
 }
 
+// GetenvOrDefault calls os>lookup for a key and returns a fallback only if variable wasn't set.
+func GetenvOrDefault(key, fallback string) string {
+	if v, ok := os.LookupEnv(key); ok {
+		return v
+	}
+	return fallback
+}
+
 // MkfsExt4 uses mkfs.ext4 to create an EXT4 file system in a given file.
 func MkfsExt4(path string) error {
 	exitCode, cmdErr := RunShellCommandNoSudo(fmt.Sprintf("mkfs.ext4 %s", path))


### PR DESCRIPTION
For the first iteration, the following has to be finished to consider this feature complete:

- [x] support the following format of the port flag: `(network-device:)?((host-port:)?dest-port)(/[udp|tcp])?` where:
  - the `network-device` is optional
  - `host-port` is optional, defaults to `dest-port`
  - protocol is optional, defaults to `/tcp`
- [x] extract the rulespecs into helper functions
- [x] implement `IPTUnpublisher` which, given VM ID and IP address, removes the VM specific chain from NAT table and rules from `FIREBUILD-FORWARD` chain for that particular VM
- [x] store exposed ports on the run metadata
- [x] clean up `iptables` on daemonized kill and purge, and non-daemonized stop
- [x] implement filesystem lock because concurrent iptables handling will not work
- [x] tests
- [x] godoc

When implemented, document desired provider based (similar to storage) iptables handlers.