### PR TITLE
Use shallow clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,7 @@ The examples use the 5.8 Linux kernel image which is built using the configurati
 ```sh
 export KERNEL_VERSION=v5.8
 mkdir -p /tmp/linux && cd /tmp/linux
-git clone https://github.com/torvalds/linux.git .
-git checkout ${KERNEL_VERSION}
+git clone -b ${KERNEL_VERSION} https://github.com/torvalds/linux.git .
 wget -O .config https://raw.githubusercontent.com/combust-labs/firebuild/master/baseos/kernel/5.8.config
 make vmlinux -j32 # adapt to the number of cores you have
 ```

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The examples use the 5.8 Linux kernel image which is built using the configurati
 ```sh
 export KERNEL_VERSION=v5.8
 mkdir -p /tmp/linux && cd /tmp/linux
-git clone -b ${KERNEL_VERSION} https://github.com/torvalds/linux.git .
+git clone -b ${KERNEL_VERSION} --depth 1 https://github.com/torvalds/linux.git .
 wget -O .config https://raw.githubusercontent.com/combust-labs/firebuild/master/baseos/kernel/5.8.config
 make vmlinux -j32 # adapt to the number of cores you have
 ```


### PR DESCRIPTION
Cloning the [torvalds/linux](https://github.com/torvalds/linux) repository requires several gigabytes of history to be retrieved.

Using `--depth 1` will only clone the commit associated with the given tag and all tree/blob objects required by it. That's a much better experience (also for GitHub).